### PR TITLE
Install local Android SDK on GitHub Actions

### DIFF
--- a/.github/scripts/gradlew_recursive.sh
+++ b/.github/scripts/gradlew_recursive.sh
@@ -18,10 +18,12 @@ set -xe
 
 # Default Gradle settings are not optimal for Android builds, override them
 # here to make the most out of the GitHub Actions build servers
-GRADLE_OPTS="$GRADLE_OPTS -Xms4g -Xmx4g"
-GRADLE_OPTS="$GRADLE_OPTS -XX:MaxMetaspaceSize=512m"
+GRADLE_OPTS="$GRADLE_OPTS -Xmx5120m"
 GRADLE_OPTS="$GRADLE_OPTS -XX:+HeapDumpOnOutOfMemoryError"
-GRADLE_OPTS="$GRADLE_OPTS -Dfile.encoding=UTF-8"
+GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.daemon=false"
+GRADLE_OPTS="$GRADLE_OPTS -Dorg.gradle.workers.max=2"
+GRADLE_OPTS="$GRADLE_OPTS -Dkotlin.incremental=false"
+GRADLE_OPTS="$GRADLE_OPTS -Dkotlin.compiler.execution.strategy=in-process"
 export GRADLE_OPTS
 
 # Crawl all gradlew files which indicate an Android project
@@ -29,6 +31,6 @@ export GRADLE_OPTS
 for GRADLEW in `find . -name "gradlew"` ; do
     SAMPLE=$(dirname "${GRADLEW}")
 
-    # Tell Gradle that this is a CI environment and disable parallel compilation
-    bash "$GRADLEW" -p "$SAMPLE" -Pci --no-parallel --stacktrace $@
+    # Tell Gradle that this is a CI environment
+    bash "$GRADLEW" -p "$SAMPLE" -Pci --stacktrace $@
 done

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,28 +14,30 @@
 
 name: Android CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
+
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+          
+      - uses: malinskiy/action-android/install-sdk@release/0.0.5
+        
       - name: Build project
         run: .github/scripts/gradlew_recursive.sh assembleDebug
+
       - name: Zip artifacts
         run: zip -r assemble.zip . -i '**/build/*.apk' '**/build/*.aab' '**/build/*.aar' '**/build/*.so'
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
The system default Android SDK is in a non-writeable location, and does not contain the R SDK. This PR updates the job to install a local, updateable Android SDK.

Also updated the job to work on any branch name, since PRs on branches should be checked too, and tweak the runner parameters.