### PR TITLE
Update readme.md

### DIFF
--- a/People/README.md
+++ b/People/README.md
@@ -24,10 +24,33 @@ Bubbles are built into the Notification system. They float on top of other app c
 the user wherever they go. Bubbles can be expanded to reveal app functionality and information, and
 can be collapsed when not being used.
 
-This example showcases bubbles that can be surfaced by a chat app. For more information on bubbles,
-see the [Bubbles][1] developer guide.
+### API Guidelines
+
+#### Conversation Requirements
+First fulfill the notification [conversation requirements][2] -- this involves implementing long-lived dynamic or [sharing shortcuts][3] and attaching the shortcut id to your messaging style notification.
+
+#### Configure Activity
+
+For your activity to display as a bubble, it must be resizable. You should expect that the bubble activity will be flagged to act like [documentLaunchMode=”always”][4].
+
+    <activity
+        android:name=".bubbles.BubbleActivity"
+        android:label="@string/title_activity_bubble"
+        android:resizeableActivity="true"
+    />
+
+#### Create your Bubble Metadata
+
+Define your [BubbleMetadata][5], defining the properties relevant to your bubble (e.g. The activity used in the expanded bubble, size, auto-expanded and etc...) and [set it on your notification][6].
+
+For more information on bubbles, see the [Bubbles][1] developer guide.
 
 [1]: https://developer.android.com/guide/topics/ui/bubbles
+[2]: https://developer.android.com/preview/features/conversations
+[3]: https://developer.android.com/training/sharing/receive#providing-direct-share-targets
+[4]: https://developer.android.com/guide/topics/manifest/activity-element#dlmode
+[5]: https://developer.android.com/reference/androidx/core/app/NotificationCompat.BubbleMetadata.Builder
+[6]: https://developer.android.com/reference/kotlin/androidx/core/app/NotificationCompat.Builder#setBubbleMetadata(androidx.core.app.NotificationCompat.BubbleMetadata)
 
 ## Pre-requisites
 


### PR DESCRIPTION
Add guidance to bubble creation. Note that the guidance is the requirements for bubble creation and doesn't completely outline the behavior of bubbles. That content will be defined in the android dev documentation.

The important info here that is lacking in the public documentation, which is for Android 10, is the conversation requirements that must be fulfilled in order for something to bubble.