### PR TITLE
Adding packaging.yaml file to allow to be imported into Android Studio

### DIFF
--- a/WindowManager/.google/packaging.yaml
+++ b/WindowManager/.google/packaging.yaml
@@ -1,0 +1,13 @@
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+status:       PUBLISHED
+technologies: [Android]
+categories:   [User Interface, Foldable and Large-screen Devices]
+languages:    [Kotlin]
+solutions:    [Mobile]
+github:       android/user-interface-samples
+license:      apache2


### PR DESCRIPTION
Adds a packaging.yaml file for the Window Manager sample to allow it to be imported into Android Studio.