### PR TITLE
People (bubbles): [FIXED] `ClassCastException` when trying to open `VoiceCallActivity`

### DIFF
--- a/People/app/src/main/java/com/example/android/people/VoiceCallActivity.kt
+++ b/People/app/src/main/java/com/example/android/people/VoiceCallActivity.kt
@@ -15,6 +15,7 @@
 
 package com.example.android.people
 
+import android.net.Uri
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.bumptech.glide.Glide
@@ -29,14 +30,14 @@ class VoiceCallActivity : AppCompatActivity(R.layout.voice_call_activity) {
 
     companion object {
         const val EXTRA_NAME = "name"
-        const val EXTRA_ICON = "icon"
+        const val EXTRA_ICON_URI = "iconUri"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val name = intent.getStringExtra(EXTRA_NAME)
-        val icon = intent.getIntExtra(EXTRA_ICON, 0)
-        if (name == null || icon == 0) {
+        val icon = intent.getParcelableExtra<Uri>(EXTRA_ICON_URI)
+        if (name == null || icon == null) {
             finish()
             return
         }

--- a/People/app/src/main/java/com/example/android/people/ui/chat/ChatFragment.kt
+++ b/People/app/src/main/java/com/example/android/people/ui/chat/ChatFragment.kt
@@ -161,7 +161,7 @@ class ChatFragment : Fragment(R.layout.chat_fragment) {
         startActivity(
             Intent(requireActivity(), VoiceCallActivity::class.java)
                 .putExtra(VoiceCallActivity.EXTRA_NAME, contact.name)
-                .putExtra(VoiceCallActivity.EXTRA_ICON, contact.icon)
+                .putExtra(VoiceCallActivity.EXTRA_ICON_URI, contact.iconUri)
         )
     }
 


### PR DESCRIPTION
The activity was created with String icon ID, but was trying to extract Int causing following exception.

```
2020-08-10 20:41:11.681 17083-17083/com.example.android.people W/Bundle: Key icon expected Integer but value was a java.lang.String.  The default value 0 was returned.
2020-08-10 20:41:11.682 17083-17083/com.example.android.people W/Bundle: Attempt to cast generated internal exception:
    java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
        at android.os.BaseBundle.getInt(BaseBundle.java:1077)
        at android.content.Intent.getIntExtra(Intent.java:8183)
        at com.example.android.people.VoiceCallActivity.onCreate(VoiceCallActivity.kt:38)
        at android.app.Activity.performCreate(Activity.java:8000)
```

Fix was to pass the Uri that can be used by Glide to show the thumbnail icon.


|  Before Fix  | After Fix  |
|---|---|
| ![device-2020-08-10-204207](https://user-images.githubusercontent.com/99822/89845147-ad046d00-db4b-11ea-89da-94e889aa5959.gif)  |  ![device-2020-08-10-204639](https://user-images.githubusercontent.com/99822/89845153-afff5d80-db4b-11ea-96de-bd92bfcd1703.gif) |



