### PR TITLE
Fix single slice viewer layout for small display height.

### DIFF
--- a/SliceViewerKotlin/app/src/main/res/layout/activity_single_slice_viewer.xml
+++ b/SliceViewerKotlin/app/src/main/res/layout/activity_single_slice_viewer.xml
@@ -18,7 +18,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:layout_marginBottom="@dimen/margin_large"
     android:layout_marginTop="@dimen/margin_large"
     android:orientation="vertical"
@@ -51,10 +51,10 @@
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/uri_value">
+        app:layout_constraintTop_toBottomOf="@+id/uri_value"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <FrameLayout
             android:layout_width="wrap_content"


### PR DESCRIPTION
If the display height is small (e.g., in landscape more, or in split view), the slice wouldn't be fully displayed.