### PR TITLE
Fixes notification settings intent in Android 8+

### DIFF
--- a/Notifications/Application/src/main/java/com/example/android/wearable/wear/wearnotifications/MainActivity.java
+++ b/Notifications/Application/src/main/java/com/example/android/wearable/wear/wearnotifications/MainActivity.java
@@ -861,6 +861,11 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
         intent.setAction("android.settings.APP_NOTIFICATION_SETTINGS");
         intent.putExtra("app_package", getPackageName());
         intent.putExtra("app_uid", getApplicationInfo().uid);
+        
+        // for Android 8 and above
+        intent.putExtra("android.provider.extra.APP_PACKAGE", getPackageName());
+
+        
         startActivity(intent);
     }
 }

--- a/Notifications/Application/src/main/java/com/example/android/wearable/wear/wearnotifications/MainActivity.java
+++ b/Notifications/Application/src/main/java/com/example/android/wearable/wear/wearnotifications/MainActivity.java
@@ -865,7 +865,6 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
         // for Android 8 and above
         intent.putExtra("android.provider.extra.APP_PACKAGE", getPackageName());
 
-        
         startActivity(intent);
     }
 }


### PR DESCRIPTION
On Android Q the app would crash when trying to open app notification settings:

```
2020-09-16 19:25:38.510 31280-31280/com.android.settings E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.android.settings, PID: 31280
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.android.settings/com.android.settings.Settings$AppNotificationSettingsActivity}: java.lang.NullPointerException: Attempt to read from field 'android.content.pm.ApplicationInfo android.content.pm.PackageInfo.applicationInfo' on a null object reference
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2913)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3048)
```

This PR fixes the issue by providing extra package name for Android 8 and above.