### PR TITLE
sample AppShortcuts static shortcut doesn't work

### DIFF
--- a/AppShortcuts/app/build.gradle
+++ b/AppShortcuts/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        applicationId "com.example.android.shortcutsample"
+        applicationId "com.example.android.shortcuts"
         minSdkVersion 25
         targetSdkVersion 28
     }


### PR DESCRIPTION
fix the bug that the static shortcut 'Add New Website' don't works. I think the reason is  applicationId doesn't equals packageName.