### PR TITLE
Update notification rather than dismiss it to retain the bubble

### DIFF
--- a/People/app/src/main/java/com/example/android/people/data/ChatRepository.kt
+++ b/People/app/src/main/java/com/example/android/people/data/ChatRepository.kt
@@ -123,12 +123,15 @@ class DefaultChatRepository internal constructor(
 
     override fun updateNotification(id: Long) {
         val chat = chats.getValue(id)
-        notificationHelper.showNotification(chat, false)
+        notificationHelper.showNotification(chat, false, true)
     }
 
     override fun activateChat(id: Long) {
+        val chat = chats.getValue(id)
         currentChat = id
-        notificationHelper.dismissNotification(id)
+        val isPrepopulatedMsgs =
+            chat.messages.size == 2 && chat.messages[0] != null && chat.messages[1] != null
+        notificationHelper.updateNotification(chat, id, isPrepopulatedMsgs)
     }
 
     override fun deactivateChat(id: Long) {

--- a/People/app/src/main/java/com/example/android/people/ui/chat/ChatViewModel.kt
+++ b/People/app/src/main/java/com/example/android/people/ui/chat/ChatViewModel.kt
@@ -38,8 +38,9 @@ class ChatViewModel @JvmOverloads constructor(
     private var _photoMimeType: String? = null
 
     /**
-     * We want to dismiss a notification when the corresponding chat screen is open. Setting this
-     * to `true` dismisses the current notification and suppresses further notifications.
+     * We want to update the notification when the corresponding chat screen is open. Setting this
+     * to `true` updates the current notification, removing the unread message(s) badge icon and
+     * suppressing further notifications.
      *
      * We do want to keep on showing and updating the notification when the chat screen is opened
      * as an expanded bubble. [ChatFragment] should set this to false if it is launched in


### PR DESCRIPTION
Retain the bubble when the app chat is opened by not dismissing it and just update notification bubble metadata via [Notification.BubbleMetadata.Builder#setSuppressNotification(true) ](https://developer.android.com/reference/android/app/Notification.BubbleMetadata.Builder#setSuppressNotification(boolean)) to remove the unread message badge icon on collapsed bubble if present, to show that message has been read.

Fixes #223 

Note that ideally, the better UX would be that the bubble is removed when the app chat is opened **but** added back when the app is no longer in foreground by reposting the same notification with the notification suppressed BubbleMetadata bit set to true. But that requires more work and I can address in a separate pull request.