### PR TITLE
Update to alpha06

### DIFF
--- a/WindowManager/app/build.gradle
+++ b/WindowManager/app/build.gradle
@@ -45,5 +45,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.window:window:1.0.0-alpha05'
+    implementation 'androidx.window:window:1.0.0-alpha06'
 }

--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/SplitLayout.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/SplitLayout.kt
@@ -25,8 +25,6 @@ import android.view.View.MeasureSpec.EXACTLY
 import android.widget.FrameLayout
 import androidx.window.DisplayFeature
 import androidx.window.FoldingFeature
-import androidx.window.FoldingFeature.TYPE_FOLD
-import androidx.window.FoldingFeature.TYPE_HINGE
 import androidx.window.WindowLayoutInfo
 
 /**
@@ -195,7 +193,6 @@ class SplitLayout : FrameLayout {
 
     private fun isValidFoldFeature(displayFeature: DisplayFeature): Boolean {
         val feature = displayFeature as? FoldingFeature ?: return false
-        return (feature.type == TYPE_FOLD || feature.type == TYPE_HINGE) &&
-            getFeaturePositionInViewRect(feature, this) != null
+        return getFeaturePositionInViewRect(feature, this) != null
     }
 }

--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/SplitLayout.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/SplitLayout.kt
@@ -191,8 +191,8 @@ class SplitLayout : FrameLayout {
             childView.measuredHeightAndState and MEASURED_STATE_TOO_SMALL == 0
     }
 
-    private fun isValidFoldFeature(displayFeature: DisplayFeature): Boolean {
-        val feature = displayFeature as? FoldingFeature ?: return false
-        return getFeaturePositionInViewRect(feature, this) != null
-    }
+    private fun isValidFoldFeature(displayFeature: DisplayFeature) =
+        (displayFeature as? FoldingFeature)?.let { feature ->
+            getFeaturePositionInViewRect(feature, this) != null
+        } ?: false
 }

--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/backend/MidScreenFoldBackend.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/backend/MidScreenFoldBackend.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import android.graphics.Point
 import android.graphics.Rect
 import androidx.core.util.Consumer
-import androidx.window.DeviceState
 import androidx.window.DisplayFeature
 import androidx.window.FoldingFeature
 import androidx.window.WindowBackend
@@ -61,7 +60,7 @@ class MidScreenFoldBackend(private val foldAxis: FoldAxis) : WindowBackend {
 
     fun getWindowLayoutInfo(context: Context): WindowLayoutInfo {
         // Use androidx.window.windowMetrics to retrieve current window size
-        val windowMetrics = WindowManager(context).currentWindowMetrics
+        val windowMetrics = WindowManager(context).getCurrentWindowMetrics()
         val windowSize = Point(windowMetrics.bounds.width(), windowMetrics.bounds.height())
         val featureRect = foldRect(windowSize)
 
@@ -113,16 +112,6 @@ class MidScreenFoldBackend(private val foldAxis: FoldAxis) : WindowBackend {
         }
     }
 
-    @Deprecated("Use FoldingFeature to get the state of the hinge instead.")
-    override fun registerDeviceStateChangeCallback(
-        executor: Executor,
-        callback: Consumer<DeviceState>
-    ) {}
-
-    @Deprecated("Use FoldingFeature to get the state of the hinge instead.")
-    override fun unregisterDeviceStateChangeCallback(callback: Consumer<DeviceState>) {
-    }
-
     override fun registerLayoutChangeCallback(
         activity: Activity,
         executor: Executor,
@@ -132,14 +121,6 @@ class MidScreenFoldBackend(private val foldAxis: FoldAxis) : WindowBackend {
         windowLayoutInfoExecutor = executor
 
         executor.execute { callback.accept(getWindowLayoutInfo(activity)) }
-    }
-
-    override fun registerLayoutChangeCallback(
-        context: Context,
-        executor: Executor,
-        callback: Consumer<WindowLayoutInfo>
-    ) {
-        TODO("Not yet implemented")
     }
 
     override fun unregisterLayoutChangeCallback(callback: Consumer<WindowLayoutInfo>) {

--- a/WindowManager/build.gradle
+++ b/WindowManager/build.gradle
@@ -15,14 +15,14 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.5.0'
     ext.ktlint_version = '0.40.0'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Update the sample to support Jetpack WindowManager-alpha06:
- Removing deprecated methods
- FoldingFeature.type is now internal
- Use getCurrentWindowMetrics()
- Update to latest stable releases:
  - AGP 4.2.0
  - Kotlin 1.5.0