### PR TITLE
Add the styles for v31 to have clipToOutline attribute

### DIFF
--- a/AppWidget/app/src/main/res/values-v31/styles.xml
+++ b/AppWidget/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2021 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+    <!--
+    Having clipToOutline to true is needed for the background (that has id with
+    android:id/background so that the system knows the widget has been updated
+    and doesn't need to be clipped by the launcher.
+    -->
+    <style name="Widget.AppWidget.AppWidget.Container" parent="android:Widget">
+        <item name="android:padding">?attr/appWidgetPadding</item>
+        <item name="android:background">@drawable/app_widget_background</item>
+        <item name="android:clipToOutline">true</item>
+    </style>
+
+    <!--
+    Having clipToOutline to true for the inner view makes sure the content of the view
+    is clipped.
+    -->
+    <style name="Widget.AppWidget.AppWidget.InnerView" parent="android:Widget">
+        <item name="android:padding">?attr/appWidgetPadding</item>
+        <item name="android:background">@drawable/app_widget_inner_view_background</item>
+        <item name="android:clipToOutline">true</item>
+    </style>
+</resources>

--- a/AppWidget/build.gradle
+++ b/AppWidget/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0-rc01'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Adding clipToOutline to true for the background of the view is needed
and recommended for the inner view of the widget for v31.
This PR adds the styles for v31 with explanation.

Also update the AGP to 4.2.1.