### PR TITLE
Update to Beta02 reintroducing state checks in test.

### DIFF
--- a/WindowManager/app/src/androidTest/java/com/example/windowmanagersample/DisplayFeaturesActivityTest.kt
+++ b/WindowManager/app/src/androidTest/java/com/example/windowmanagersample/DisplayFeaturesActivityTest.kt
@@ -78,6 +78,7 @@ class DisplayFeaturesActivityTest {
                 )
             }
         }
+        onView(withId(R.id.state_update_log)).check(matches(withSubstring("state = FLAT")))
         onView(withId(R.id.current_state)).check(matches(withSubstring("is not separated")))
         onView(withId(R.id.current_state)).check(matches(withSubstring("Hinge is horizontal")))
     }
@@ -100,6 +101,7 @@ class DisplayFeaturesActivityTest {
                 )
             }
         }
+        onView(withId(R.id.state_update_log)).check(matches(withSubstring("state = HALF_OPENED")))
         onView(withId(R.id.current_state)).check(matches(withSubstring("are separated")))
         onView(withId(R.id.current_state)).check(matches(withSubstring("Hinge is horizontal")))
     }
@@ -122,6 +124,7 @@ class DisplayFeaturesActivityTest {
                 )
             }
         }
+        onView(withId(R.id.state_update_log)).check(matches(withSubstring("state = HALF_OPENED")))
         onView(withId(R.id.current_state)).check(matches(withSubstring("are separated")))
         onView(withId(R.id.current_state)).check(matches(withSubstring("Hinge is vertical")))
     }

--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/DisplayFeaturesActivity.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/DisplayFeaturesActivity.kt
@@ -32,7 +32,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
@@ -46,7 +45,6 @@ class DisplayFeaturesActivity : AppCompatActivity() {
     private lateinit var binding: ActivityDisplayFeaturesBinding
     private lateinit var windowInfoRepository: WindowInfoRepository
 
-    @ExperimentalCoroutinesApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/WindowManager/build.gradle
+++ b/WindowManager/build.gradle
@@ -15,16 +15,16 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.5.30'
     ext.coroutines_version = '1.5.0'
     ext.ktlint_version = '0.40.0'
-    ext.window_version = '1.0.0-beta01'
+    ext.window_version = '1.0.0-beta02'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Jetpack WindowManager beta02 add [`toString` method for `FakeFoldingFeature`][1] and we can how reintroduce checks in  `DisplayFeaturesActivityTest.kt` that we had to remove previously.



[1]: https://android.googlesource.com/platform/frameworks/support/+/e756a1333ff4a1b6a666e204a51507c48ea46427