### PR TITLE
Add missing android:id for v31

### DIFF
--- a/AppWidget/app/src/main/res/values-v21/styles.xml
+++ b/AppWidget/app/src/main/res/values-v21/styles.xml
@@ -19,6 +19,7 @@ requires API level 21
 -->
 <resources>
     <style name="Widget.AppWidget.AppWidget.Container" parent="android:Widget">
+        <item name="android:id">@android:id/background</item>
         <item name="android:padding">?attr/appWidgetPadding</item>
         <item name="android:background">@drawable/app_widget_background</item>
     </style>

--- a/AppWidget/app/src/main/res/values-v31/styles.xml
+++ b/AppWidget/app/src/main/res/values-v31/styles.xml
@@ -21,6 +21,7 @@
     and doesn't need to be clipped by the launcher.
     -->
     <style name="Widget.AppWidget.AppWidget.Container" parent="android:Widget">
+        <item name="android:id">@android:id/background</item>
         <item name="android:padding">?attr/appWidgetPadding</item>
         <item name="android:background">@drawable/app_widget_background</item>
         <item name="android:clipToOutline">true</item>


### PR DESCRIPTION
android:id="@android:id/background" was missing from the style of the
widget background from the v31 variant(other variants have that).
That resulted in the gap between the outlined border when the widget is
being resized with the widget background.

Before
<img src="https://user-images.githubusercontent.com/796361/135786903-da81dc15-b90e-42c6-8f65-d726329a8e22.png" width="300"  />

After
<img src="https://user-images.githubusercontent.com/796361/135787053-3b0fbbfa-a038-4aaf-a764-0ca0ca5ea3b5.png" width="300"  />

