### PR TITLE
Add a layout specific to preview for a layout including ListView

### DIFF
--- a/AppWidget/app/src/main/res/layout/widget_items_collection_preview.xml
+++ b/AppWidget/app/src/main/res/layout/widget_items_collection_preview.xml
@@ -13,6 +13,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+<!--
+This layout file is meant to be used only for the previewLayout attribute
+to mimic the fake items in the ListView to follow the recommended practice
+at https://developer.android.com/guide/topics/appwidgets/advanced#build-accurate-previews.
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/Widget.AppWidget.AppWidget.Container"
     android:layout_width="match_parent"

--- a/AppWidget/app/src/main/res/layout/widget_items_collection_preview.xml
+++ b/AppWidget/app/src/main/res/layout/widget_items_collection_preview.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright (C) 2021 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Widget.AppWidget.AppWidget.Container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:theme="@style/Theme.AppWidget.AppWidgetContainer">
+
+    <include layout="@layout/widget_items_collection"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+    <include layout="@layout/item_checkboxes"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+    <include layout="@layout/item_radio_buttons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+    <include layout="@layout/item_switches"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+</LinearLayout>

--- a/AppWidget/app/src/main/res/xml/app_widget_items_list.xml
+++ b/AppWidget/app/src/main/res/xml/app_widget_items_list.xml
@@ -26,6 +26,7 @@ Thus, only supplying a static image through android:previewImage
     android:minWidth="180dp"
     android:minHeight="220dp"
     android:previewImage="@drawable/items_collection_widget_preview"
+    android:previewLayout="@layout/widget_items_collection_preview"
     android:resizeMode="horizontal|vertical"
     android:targetCellWidth="3"
     android:targetCellHeight="4"


### PR DESCRIPTION
To display more accurate preview in the widget picker,
follow the recommendations explained at the [advanced page for widgets guide](https://developer.android.com/guide/topics/appwidgets/advanced#build-accurate-previews)

Screenshots of the preview after patching this PR.

<img src="https://user-images.githubusercontent.com/796361/137429857-8241a757-c5d4-4071-a1d4-0d55da118f7d.png" width="300px" />

<img src="https://user-images.githubusercontent.com/796361/137430107-7412c3c5-046e-4322-949e-685ed86df577.png" width="300px" />


