### PR TITLE
Handle configuration changes adding a utility view.

### DIFF
--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/WindowMetricsActivity.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/WindowMetricsActivity.kt
@@ -19,6 +19,8 @@ package com.example.windowmanagersample
 import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.window.layout.WindowMetricsCalculator
 import com.example.windowmanagersample.databinding.ActivityWindowMetricsBinding
@@ -40,12 +42,24 @@ class WindowMetricsActivity : AppCompatActivity() {
         adapter.append("onCreate", "triggered")
 
         logCurrentWindowMetrics("onCreate")
-    }
 
-    @SuppressLint("NotifyDataSetChanged")
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        logCurrentWindowMetrics("Config.Change")
+        val container: ViewGroup = binding.root
+
+        // Add a utility view to the container to hook into
+        // View.onConfigurationChanged.
+        // This is required for all activities, even those that don't
+        // handle configuration changes.
+        // We also can't use Activity.onConfigurationChanged, since there
+        // are situations where that won't be called when the configuration
+        // changes.
+        // View.onConfigurationChanged is called in those scenarios.
+        container.addView(object : View(this) {
+            override fun onConfigurationChanged(newConfig: Configuration?) {
+                super.onConfigurationChanged(newConfig)
+                logCurrentWindowMetrics("Config.Change")
+            }
+        })
+
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/WindowManager/app/src/main/res/layout/activity_window_metrics.xml
+++ b/WindowManager/app/src/main/res/layout/activity_window_metrics.xml
@@ -14,10 +14,15 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-
+<LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 <androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/recycler_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
+</LinearLayout>


### PR DESCRIPTION
As described in [**Support different screen sizes**][1], we're adding a utility view to the container to hook into `View.onConfigurationChanged`.
This is required for all activities, even those that don't handle configuration changes.
We also can't use `Activity.onConfigurationChanged`, since there are situations where that won't be called when the configuration changes.
`View.onConfigurationChanged` is called in those scenarios.



[1]: https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes