### PR TITLE
Update to Jetpack WindowManager beta04

### DIFF
--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/DisplayFeaturesActivity.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/DisplayFeaturesActivity.kt
@@ -25,8 +25,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.window.layout.FoldingFeature
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
+import androidx.window.layout.WindowInfoTracker
 import androidx.window.layout.WindowLayoutInfo
 import com.example.windowmanagersample.databinding.ActivityDisplayFeaturesBinding
 import java.text.SimpleDateFormat
@@ -42,15 +41,12 @@ class DisplayFeaturesActivity : AppCompatActivity() {
     private val stateLog: StringBuilder = StringBuilder()
 
     private lateinit var binding: ActivityDisplayFeaturesBinding
-    private lateinit var windowInfoRepository: WindowInfoRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         binding = ActivityDisplayFeaturesBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
-        windowInfoRepository = windowInfoRepository()
 
         // Create a new coroutine since repeatOnLifecycle is a suspend function
         lifecycleScope.launch(Dispatchers.Main) {
@@ -60,7 +56,8 @@ class DisplayFeaturesActivity : AppCompatActivity() {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 // Safely collects from windowInfoRepository when the lifecycle is STARTED
                 // and stops collection when the lifecycle is STOPPED.
-                windowInfoRepository.windowLayoutInfo
+                WindowInfoTracker.getOrCreate(this@DisplayFeaturesActivity)
+                    .windowLayoutInfo(this@DisplayFeaturesActivity)
                     .collect { newLayoutInfo ->
                         updateStateLog(newLayoutInfo)
                         updateCurrentState(newLayoutInfo)

--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/RxActivity.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/RxActivity.kt
@@ -22,8 +22,7 @@ import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.window.layout.FoldingFeature
-import androidx.window.layout.WindowInfoRepository
-import androidx.window.layout.WindowInfoRepository.Companion.windowInfoRepository
+import androidx.window.layout.WindowInfoTracker
 import androidx.window.layout.WindowLayoutInfo
 import androidx.window.rxjava2.layout.windowLayoutInfoObservable
 import com.example.windowmanagersample.databinding.ActivityRxBinding
@@ -41,7 +40,6 @@ class RxActivity : AppCompatActivity() {
     private var disposable: Disposable? = null
 
     private lateinit var binding: ActivityRxBinding
-    private lateinit var windowInfoRepository: WindowInfoRepository
     private lateinit var observable: Observable<WindowLayoutInfo>
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -50,10 +48,9 @@ class RxActivity : AppCompatActivity() {
         binding = ActivityRxBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        windowInfoRepository = windowInfoRepository()
-
         // Create a new observable
-        observable = windowInfoRepository.windowLayoutInfoObservable()
+        observable = WindowInfoTracker.getOrCreate(this@RxActivity)
+            .windowLayoutInfoObservable(this@RxActivity)
 
         stateLog.clear()
         stateLog.append(getString(R.string.state_update_log)).append("\n")

--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/SplitLayoutActivity.java
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/SplitLayoutActivity.java
@@ -20,14 +20,14 @@ import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.util.Consumer;
-import androidx.window.java.layout.WindowInfoRepositoryCallbackAdapter;
-import androidx.window.layout.WindowInfoRepository;
+import androidx.window.java.layout.WindowInfoTrackerCallbackAdapter;
+import androidx.window.layout.WindowInfoTracker;
 import androidx.window.layout.WindowLayoutInfo;
 import com.example.windowmanagersample.databinding.ActivitySplitLayoutBinding;
 
 public class SplitLayoutActivity extends AppCompatActivity {
 
-    private WindowInfoRepositoryCallbackAdapter windowInfoRepository;
+    private WindowInfoTrackerCallbackAdapter windowInfoTracker;
     private ActivitySplitLayoutBinding binding;
     private final LayoutStateChangeCallback layoutStateChangeCallback =
             new LayoutStateChangeCallback();
@@ -39,20 +39,21 @@ public class SplitLayoutActivity extends AppCompatActivity {
         binding = ActivitySplitLayoutBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        windowInfoRepository =
-                new WindowInfoRepositoryCallbackAdapter(WindowInfoRepository.getOrCreate(this));
+        windowInfoTracker =
+                new WindowInfoTrackerCallbackAdapter(WindowInfoTracker.getOrCreate(this));
     }
 
     @Override
     protected void onStart() {
         super.onStart();
-        windowInfoRepository.addWindowLayoutInfoListener(Runnable::run, layoutStateChangeCallback);
+        windowInfoTracker.addWindowLayoutInfoListener(
+                this, Runnable::run, layoutStateChangeCallback);
     }
 
     @Override
     protected void onStop() {
         super.onStop();
-        windowInfoRepository.removeWindowLayoutInfoListener(layoutStateChangeCallback);
+        windowInfoTracker.removeWindowLayoutInfoListener(layoutStateChangeCallback);
     }
 
     class LayoutStateChangeCallback implements Consumer<WindowLayoutInfo> {

--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/WindowMetricsActivity.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/WindowMetricsActivity.kt
@@ -59,7 +59,6 @@ class WindowMetricsActivity : AppCompatActivity() {
                 logCurrentWindowMetrics("Config.Change")
             }
         })
-
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/WindowManager/build.gradle
+++ b/WindowManager/build.gradle
@@ -18,8 +18,7 @@ buildscript {
     ext.kotlin_version = '1.5.31'
     ext.coroutines_version = '1.5.0'
     ext.ktlint_version = '0.40.0'
-    ext.window_version = '1.0.0-SNAPSHOT'
-//    ext.window_version = '1.0.0-beta03'
+    ext.window_version = '1.0.0-beta04'
     repositories {
         google()
         mavenCentral()
@@ -61,6 +60,5 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://androidx.dev/snapshots/builds/7904636/artifacts/repository' }
     }
 }

--- a/WindowManager/build.gradle
+++ b/WindowManager/build.gradle
@@ -18,7 +18,8 @@ buildscript {
     ext.kotlin_version = '1.5.31'
     ext.coroutines_version = '1.5.0'
     ext.ktlint_version = '0.40.0'
-    ext.window_version = '1.0.0-beta03'
+    ext.window_version = '1.0.0-SNAPSHOT'
+//    ext.window_version = '1.0.0-beta03'
     repositories {
         google()
         mavenCentral()
@@ -60,5 +61,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://androidx.dev/snapshots/builds/7904636/artifacts/repository' }
     }
 }


### PR DESCRIPTION
Handles changes in the API for beta04.

From the [release notes][1]:
* Rename `WindowInfoRepository` to `WindowInfoTracker`.
* Make Activity an explicit method dependency for WindowInfoTracker.

[1]: https://developer.android.com/jetpack/androidx/releases/window#1.0.0-beta04