### PR TITLE
Update "Android on Chrome OS - Drag and Drop Demo" sample to use DragStartHelper and DropHelper

### DIFF
--- a/AndroidOnChromeOSDragAndDropDemo/README.md
+++ b/AndroidOnChromeOSDragAndDropDemo/README.md
@@ -6,6 +6,14 @@ A demo android application demonstrating basic Drag and Drop functionality
 with Chrome OS in mind.
 
 Allows for plain-text items and files from the Chrome OS file manager to be
-dragged into the app. Has a plain-text item that can be dragged out.
+dragged into the app as well as PNGs and JPEGs. Has a plain-text item and PNG that can be dragged
+out of the app.
+
+Utilizes [`androix.core`](https://developer.android.com/jetpack/androidx/releases/core)'s [`DragStartHelper`](https://developer.android.com/reference/kotlin/androidx/core/view/DragStartHelper) 
+and [`androidx.draganddrop`](https://developer.android.com/jetpack/androidx/releases/draganddrop)'s `DropHelper` to simplify
+the process of implementing both dragging and dropping functionality.
+
+## Screenshots
+![Animation of the sample app. Text and images are dragged and dropped between two instances of the app](screenshots/drag-n-drop.gif)
 
 For reference and education only.

--- a/AndroidOnChromeOSDragAndDropDemo/README.md
+++ b/AndroidOnChromeOSDragAndDropDemo/README.md
@@ -9,7 +9,7 @@ Allows for plain-text items and files from the Chrome OS file manager to be
 dragged into the app as well as PNGs and JPEGs. Has a plain-text item and PNG that can be dragged
 out of the app.
 
-Utilizes [`androix.core`](https://developer.android.com/jetpack/androidx/releases/core)'s [`DragStartHelper`](https://developer.android.com/reference/kotlin/androidx/core/view/DragStartHelper) 
+Utilizes [`androidx.core`](https://developer.android.com/jetpack/androidx/releases/core)'s [`DragStartHelper`](https://developer.android.com/reference/kotlin/androidx/core/view/DragStartHelper) 
 and [`androidx.draganddrop`](https://developer.android.com/jetpack/androidx/releases/draganddrop)'s `DropHelper` to simplify
 the process of implementing both dragging and dropping functionality.
 

--- a/AndroidOnChromeOSDragAndDropDemo/app/build.gradle
+++ b/AndroidOnChromeOSDragAndDropDemo/app/build.gradle
@@ -50,10 +50,11 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation 'androidx.draganddrop:draganddrop:1.0.0-SNAPSHOT'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/AndroidOnChromeOSDragAndDropDemo/app/src/main/res/drawable/bg_drop_enter.xml
+++ b/AndroidOnChromeOSDragAndDropDemo/app/src/main/res/drawable/bg_drop_enter.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <corners android:radius="6dp" />
-    <stroke
-        android:width="2dp"
-        android:color="@color/black" />
-    <solid android:color="@color/purple_200" />
-</shape>

--- a/AndroidOnChromeOSDragAndDropDemo/app/src/main/res/drawable/bg_drop_highlight.xml
+++ b/AndroidOnChromeOSDragAndDropDemo/app/src/main/res/drawable/bg_drop_highlight.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <corners android:radius="6dp" />
-    <stroke
-        android:width="2dp"
-        android:color="@color/black" />
-    <solid android:color="@color/purple_300" />
-</shape>

--- a/AndroidOnChromeOSDragAndDropDemo/app/src/main/res/values/dimens.xml
+++ b/AndroidOnChromeOSDragAndDropDemo/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="drop_target_corner_radius">6dp</dimen>
+</resources>

--- a/AndroidOnChromeOSDragAndDropDemo/settings.gradle
+++ b/AndroidOnChromeOSDragAndDropDemo/settings.gradle
@@ -15,6 +15,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://androidx.dev/snapshots/latest/artifacts/repository' }
     }
 }
 rootProject.name = "DragAndDropSample"


### PR DESCRIPTION
- Utilize DragStartHelper and DropHelper to simplify drag and drop implementation
- Add screenshot
- Update README
- Bump dependencies