### PR TITLE
Apply the background for the FirstGlanceWidget  that uses color resources

### DIFF
--- a/AppWidget/glance-widget/src/main/java/com/example/android/glancewidget/FirstGlanceWidget.kt
+++ b/AppWidget/glance-widget/src/main/java/com/example/android/glancewidget/FirstGlanceWidget.kt
@@ -21,12 +21,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.glance.Button
 import androidx.glance.GlanceModifier
+import androidx.glance.ImageProvider
 import androidx.glance.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.appWidgetBackground
 import androidx.glance.appwidget.background
 import androidx.glance.appwidget.cornerRadius
+import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
@@ -48,7 +50,7 @@ class FirstGlanceWidget : GlanceAppWidget() {
         Column(
             modifier = GlanceModifier
                 .fillMaxSize()
-                .background(day = Color.White, night = Color.Black)
+                .background(ImageProvider(R.drawable.app_widget_background))
                 .appWidgetBackground()
                 .appWidgetBackgroundRadius()
                 .padding(16.dp)


### PR DESCRIPTION
Apply the background for the FirstGlanceWidget like TodoListGlanceWidget
from the drawable that uses color resources

based on the variants:
- values/colors.xml
- values-v31/colors.xml
- values-night/colors.xml
- values-night-v31/colors.xml

follow up of #303 