### PR TITLE
Allow external items on Chrome OS - Android 9

### DIFF
--- a/AndroidOnChromeOSDragAndDropDemo/app/src/main/java/dev/hadrosaur/draganddropsample/MainActivity.kt
+++ b/AndroidOnChromeOSDragAndDropDemo/app/src/main/java/dev/hadrosaur/draganddropsample/MainActivity.kt
@@ -135,7 +135,11 @@ class MainActivity : AppCompatActivity() {
         DropHelper.configureView(
             this,
             binding.textDropTarget,
-            arrayOf(MIMETYPE_TEXT_PLAIN, "image/*"),
+            arrayOf(
+                MIMETYPE_TEXT_PLAIN,
+                "image/*",
+                "application/x-arc-uri-list" // Support external items on Chrome OS Android 9
+            ),
             DropHelper.Options.Builder()
                 .setHighlightColor(getColor(R.color.purple_300))
                 // Match the radius of the view's background drawable


### PR DESCRIPTION
In Android 9 on Chrome OS, external items dragged into an app
will have the MIME type "application/x-arc-uri-list".

This allows those items to be dragged into the app. This is no
longer needed on Chrome OS in Android 11+