### PR TITLE
Add information for Activity.onConfigurationChanged not being called

### DIFF
--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/WindowMetricsActivity.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/WindowMetricsActivity.kt
@@ -52,6 +52,7 @@ class WindowMetricsActivity : AppCompatActivity() {
         // are situations where that won't be called when the configuration
         // changes.
         // View.onConfigurationChanged is called in those scenarios.
+        // https://issuetracker.google.com/202338815
         container.addView(object : View(this) {
             override fun onConfigurationChanged(newConfig: Configuration?) {
                 super.onConfigurationChanged(newConfig)


### PR DESCRIPTION
Add reference to public [bug][1] regarding `Activity.onConfigurationChanged` not being called.

[1]: https://issuetracker.google.com/202338815