### PR TITLE
Calculate dp in WindowMetricsActivity

### DIFF
--- a/WindowManager/app/src/main/java/com/example/windowmanagersample/WindowMetricsActivity.kt
+++ b/WindowManager/app/src/main/java/com/example/windowmanagersample/WindowMetricsActivity.kt
@@ -67,7 +67,13 @@ class WindowMetricsActivity : AppCompatActivity() {
             .computeCurrentWindowMetrics(this@WindowMetricsActivity)
         val width = windowMetrics.bounds.width()
         val height = windowMetrics.bounds.height()
-        adapter.append(tag, "width: $width, height: $height")
+        adapter.append(
+            tag,
+            "width: $width, " +
+                    "height: $height, " +
+                    "widthDp: ${width / resources.displayMetrics.density}, " +
+                    "heightDp: ${height / resources.displayMetrics.density}"
+        )
         runOnUiThread {
             adapter.notifyDataSetChanged()
         }


### PR DESCRIPTION
A small update to the `WindowMetricsActivity` to display both the pixel size and the dp size of the current window metrics. Seeing the dp size allows determining the corresponding window size classes much easier.