### PR TITLE
Use URIs instead of bitmaps for ImageGlanceWidget.kt

### DIFF
--- a/AppWidget/app/src/main/AndroidManifest.xml
+++ b/AppWidget/app/src/main/AndroidManifest.xml
@@ -105,8 +105,7 @@
         <receiver
             android:name=".glance.weather.WeatherGlanceWidgetReceiver"
             android:enabled="@bool/glance_appwidget_available"
-            android:exported="false"
-            android:label="@string/glance_weather">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>

--- a/AppWidget/app/src/main/AndroidManifest.xml
+++ b/AppWidget/app/src/main/AndroidManifest.xml
@@ -17,6 +17,13 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.HOME" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -98,7 +105,8 @@
         <receiver
             android:name=".glance.weather.WeatherGlanceWidgetReceiver"
             android:enabled="@bool/glance_appwidget_available"
-            android:exported="false">
+            android:exported="false"
+            android:label="@string/glance_weather">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -134,6 +142,16 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/app_widget_image_glance" />
         </receiver>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.example.android.appwidget.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/image_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/AppWidget/app/src/main/java/com/example/android/appwidget/glance/image/ImageGlanceWidget.kt
+++ b/AppWidget/app/src/main/java/com/example/android/appwidget/glance/image/ImageGlanceWidget.kt
@@ -20,11 +20,13 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.net.toUri
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
@@ -39,6 +41,7 @@ import androidx.glance.appwidget.CircularProgressIndicator
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.ImageProvider
 import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.action.ActionCallback
 import androidx.glance.appwidget.action.actionRunCallback
@@ -162,6 +165,10 @@ class ImageGlanceWidget : GlanceAppWidget() {
      * https://developer.android.com/training/secure-file-sharing/share-file#GrantPermissions
      */
     private fun getImageProvider(path: String): ImageProvider {
+        if (path.startsWith("content://")) {
+            Log.d("MPB", "Load image from content provider")
+            return ImageProvider(path.toUri())
+        }
         val bitmap = BitmapFactory.decodeFile(path)
         return ImageProvider(bitmap)
     }

--- a/AppWidget/app/src/main/java/com/example/android/appwidget/glance/image/ImageGlanceWidget.kt
+++ b/AppWidget/app/src/main/java/com/example/android/appwidget/glance/image/ImageGlanceWidget.kt
@@ -155,18 +155,18 @@ class ImageGlanceWidget : GlanceAppWidget() {
     }
 
     /**
-     * Get the bitmap from the cache file
+     * Create an ImageProvider using an URI if it's a "content://" type, otherwise load
+     * the bitmap from the cache file
      *
-     * Note: Because it's a single image resized to the available space, you
-     * probably won't reach the memory limit. If you do reach the memory limit,
-     * you'll need to generate a URI granting permissions to the launcher.
+     * Note: When using bitmaps directly your might reach the memory limit for RemoteViews.
+     * If you do reach the memory limit, you'll need to generate a URI granting permissions
+     * to the launcher.
      *
      * More info:
      * https://developer.android.com/training/secure-file-sharing/share-file#GrantPermissions
      */
     private fun getImageProvider(path: String): ImageProvider {
         if (path.startsWith("content://")) {
-            Log.d("MPB", "Load image from content provider")
             return ImageProvider(path.toUri())
         }
         val bitmap = BitmapFactory.decodeFile(path)

--- a/AppWidget/app/src/main/java/com/example/android/appwidget/glance/image/ImageWorker.kt
+++ b/AppWidget/app/src/main/java/com/example/android/appwidget/glance/image/ImageWorker.kt
@@ -165,7 +165,7 @@ class ImageWorker(
                 imageFile
             )
 
-            // Find the current launcher to grant permissions
+            // Find the current launcher everytime to ensure it has read permissions
             val resolveInfo = context.packageManager.resolveActivity(
                 Intent(Intent.ACTION_MAIN).apply { addCategory(Intent.CATEGORY_HOME) },
                 PackageManager.MATCH_DEFAULT_ONLY

--- a/AppWidget/app/src/main/java/com/example/android/appwidget/glance/image/ImageWorker.kt
+++ b/AppWidget/app/src/main/java/com/example/android/appwidget/glance/image/ImageWorker.kt
@@ -17,8 +17,13 @@
 package com.example.android.appwidget.glance.image
 
 import android.content.Context
+import android.content.Intent
+import android.content.Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
+import android.content.pm.PackageManager
 import android.util.Log
 import androidx.compose.ui.unit.DpSize
+import androidx.core.content.FileProvider.getUriForFile
 import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.state.updateAppWidgetState
@@ -151,7 +156,31 @@ class ImageWorker(
 
         // Get the path of the loaded image from DiskCache.
         val path = context.imageLoader.diskCache?.get(url)?.use { snapshot ->
-            snapshot.data.toFile().path
+            val imageFile = snapshot.data.toFile()
+
+            // Use the FileProvider to create a content URI
+            val contentUri = getUriForFile(
+                context,
+                "com.example.android.appwidget.fileprovider",
+                imageFile
+            )
+
+            // Find the current launcher to grant permissions
+            val resolveInfo = context.packageManager.resolveActivity(
+                Intent(Intent.ACTION_MAIN).apply { addCategory(Intent.CATEGORY_HOME) },
+                PackageManager.MATCH_DEFAULT_ONLY
+            )
+            val launcherName = resolveInfo?.activityInfo?.packageName
+            if (launcherName != null) {
+                context.grantUriPermission(
+                    launcherName,
+                    contentUri,
+                    FLAG_GRANT_READ_URI_PERMISSION or FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                )
+            }
+
+            // return the path
+            contentUri.toString()
         }
         return requireNotNull(path) {
             "Couldn't find cached file"

--- a/AppWidget/app/src/main/res/xml/image_paths.xml
+++ b/AppWidget/app/src/main/res/xml/image_paths.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2021 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<paths>
+    <cache-path name="widget_images" path="image_cache/" />
+</paths>


### PR DESCRIPTION
By using a FileProvider we can directly provide access to the image in the cache to the launcher.

Note: this approach has some issues when the launcher is not the default or another process is hosting the widget instead.