### PR TITLE
SplashScreen: Fix the theme switch

### DIFF
--- a/SplashScreen/app/build.gradle
+++ b/SplashScreen/app/build.gradle
@@ -20,6 +20,8 @@ plugins {
 }
 
 android {
+    namespace 'com.example.android.splashscreen'
+    testNamespace 'com.example.android.splashscreen.test'
     compileSdkVersion 33
 
     defaultConfig {
@@ -52,10 +54,10 @@ dependencies {
     // Use the SplashScreen compat library.
     implementation 'androidx.core:core-splashscreen:1.0.0'
 
-    implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.activity:activity-ktx:1.5.1'
-    implementation 'androidx.appcompat:appcompat:1.5.0'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.activity:activity-ktx:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.7.0'
 
     def lifecycle_version = '2.5.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"

--- a/SplashScreen/app/src/androidTest/AndroidManifest.xml
+++ b/SplashScreen/app/src/androidTest/AndroidManifest.xml
@@ -16,7 +16,7 @@
 -->
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.android.splashscreen.test">
+    >
 
     <!-- Export the activities from AndroidX Testing Library. -->
     <application>

--- a/SplashScreen/app/src/main/AndroidManifest.xml
+++ b/SplashScreen/app/src/main/AndroidManifest.xml
@@ -14,9 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
 -->
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.android.splashscreen">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="false"

--- a/SplashScreen/app/src/main/java/com/example/android/splashscreen/MainActivity.kt
+++ b/SplashScreen/app/src/main/java/com/example/android/splashscreen/MainActivity.kt
@@ -50,14 +50,11 @@ abstract class MainActivity : AppCompatActivity() {
 
         // Show the in-app dark theme settings. This is available on API level 31 and above.
         if (Build.VERSION.SDK_INT >= 31) {
-            var previousMode: Int? = null
             viewModel.nightMode.observe(this) { nightMode ->
                 val radioButtonId = radioButtonId(nightMode)
                 if (binding.theme.checkedRadioButtonId != radioButtonId) {
                     binding.theme.check(radioButtonId)
                 }
-                if (previousMode == null) previousMode = nightMode
-                if (previousMode != nightMode) recreate()
             }
             binding.theme.setOnCheckedChangeListener { _, checkedId ->
                 viewModel.updateNightMode(nightMode(checkedId))

--- a/SplashScreen/app/src/main/res/values-night/colors.xml
+++ b/SplashScreen/app/src/main/res/values-night/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (C) 2021 The Android Open Source Project
+  ~ Copyright (C) 2022 The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,9 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Base.Theme.App" parent="Theme.MaterialComponents.NoActionBar">
-        <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
-    </style>
+<resources>
+    <color name="splash_screen_background">@color/blue_gray_900</color>
 </resources>

--- a/SplashScreen/app/src/main/res/values/colors.xml
+++ b/SplashScreen/app/src/main/res/values/colors.xml
@@ -19,4 +19,7 @@
     <color name="lime_700">#AFB42B</color>
     <color name="blue_gray_500">#607D8B</color>
     <color name="blue_gray_700">#455A64</color>
+    <color name="blue_gray_900">#263238</color>
+
+    <color name="splash_screen_background">@color/lime_500</color>
 </resources>

--- a/SplashScreen/app/src/main/res/values/themes.xml
+++ b/SplashScreen/app/src/main/res/values/themes.xml
@@ -18,6 +18,7 @@
 
     <style name="Base.Theme.App" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:windowLightStatusBar" tools:targetApi="23">true</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
     </style>
 
     <!--
@@ -60,7 +61,7 @@
         <!-- The background color behind the icon. -->
         <item name="windowSplashScreenIconBackgroundColor">@color/lime_700</item>
         <!-- The background color for the splash screen. -->
-        <item name="windowSplashScreenBackground">@color/lime_500</item>
+        <item name="windowSplashScreenBackground">@color/splash_screen_background</item>
         <!-- The duration, in milliseconds, of the icon animation of the splash screen. -->
         <item name="windowSplashScreenAnimationDuration">1000</item>
         <!-- The 'core-splashscreen' switches the theme back to this after splash screen. -->

--- a/SplashScreen/build.gradle
+++ b/SplashScreen/build.gradle
@@ -15,13 +15,13 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/SplashScreen/gradle/wrapper/gradle-wrapper.properties
+++ b/SplashScreen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jul 29 11:47:27 JST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fix the theme switch by removing a call to Activity#create(). It seems to be no longer necessary.

Also update the splash background color so that the light/dark themes are easier to tell apart during splash screen.

Change-Id: I03b1b3fcb4550e2537fdcf1f5860276161ac4462