### PR TITLE
People: crashes on click in chat list when notifications permission isn't granted

### DIFF
--- a/People/app/src/main/java/com/example/android/people/ui/main/HeaderAdapter.kt
+++ b/People/app/src/main/java/com/example/android/people/ui/main/HeaderAdapter.kt
@@ -23,6 +23,9 @@ import com.example.android.people.R
 import com.example.android.people.databinding.ContactHeaderBinding
 
 class HeaderAdapter(private val onClick: () -> Unit) : RecyclerView.Adapter<HeaderViewHolder>() {
+    init {
+        setHasStableIds(true)
+    }
 
     private var cachedHolder: HeaderViewHolder? = null
 

--- a/People/app/src/main/java/com/example/android/people/ui/main/MainFragment.kt
+++ b/People/app/src/main/java/com/example/android/people/ui/main/MainFragment.kt
@@ -75,7 +75,8 @@ class MainFragment : Fragment(R.layout.main_fragment) {
                 is PermissionStatus.Granted -> binding.contacts.adapter = contactAdapter
                 // We don't have the permission. Show the permission header.
                 is PermissionStatus.Denied -> {
-                    binding.contacts.adapter = ConcatAdapter(headerAdapter, contactAdapter)
+                    val config = ConcatAdapter.Config.Builder().setStableIdMode(ConcatAdapter.Config.StableIdMode.SHARED_STABLE_IDS).build()
+                    binding.contacts.adapter = ConcatAdapter(config, headerAdapter, contactAdapter)
                     headerAdapter.shouldShowRationale = status.shouldShowRationale
                 }
             }


### PR DESCRIPTION
By default `ConcatAdapter` has no stable IDs, which leads to `NO_ID` appearing in `onChatClicked` handler, causing a crash