### PR TITLE
Fixes for display issues in activity embedding sample.

### DIFF
--- a/WindowManager/app/src/main/res/values/styles.xml
+++ b/WindowManager/app/src/main/res/values/styles.xml
@@ -22,6 +22,7 @@
         <item name="colorPrimary">@color/color_primary</item>
         <item name="colorPrimaryDark">@color/color_primary_dark</item>
         <item name="colorAccent">@color/color_accent</item>
+        <item name="actionBarSize">64dp</item>
     </style>
 
 </resources>

--- a/WindowManager/app/src/main/res/xml/main_split_config.xml
+++ b/WindowManager/app/src/main/res/xml/main_split_config.xml
@@ -19,7 +19,6 @@
     <SplitPairRule
         window:splitRatio="0.3"
         window:splitMinWidth="600dp"
-        window:splitLayoutDirection="ltr"
         window:finishPrimaryWithSecondary="always"
         window:finishSecondaryWithPrimary="adjacent">
         <SplitPairFilter


### PR DESCRIPTION
Removed a split pair rule configuration setting to prevent the layout direction of the activity split from changing when an item is selected from the item list.

Added a style item to ensure the action bar is the same height for both activities in a split.