### PR TITLE
Show both list and detail at expanded and above only

### DIFF
--- a/CanonicalLayouts/list-detail-activity-embedding/app/src/main/res/xml/split_configuration.xml
+++ b/CanonicalLayouts/list-detail-activity-embedding/app/src/main/res/xml/split_configuration.xml
@@ -20,7 +20,7 @@
     <!-- Automatically split the following activity pairs. -->
     <SplitPairRule
         window:splitRatio="0.3"
-        window:splitMinWidth="600dp"
+        window:splitMinWidth="840dp"
         window:finishPrimaryWithSecondary="adjacent"
         window:finishSecondaryWithPrimary="always">
         <SplitPairFilter
@@ -36,7 +36,7 @@
     <SplitPlaceholderRule
         window:placeholderActivityName=".PlaceholderActivity"
         window:splitRatio="0.3"
-        window:splitMinWidth="600dp">
+        window:splitMinWidth="840dp">
         <ActivityFilter
             window:activityName=".MainActivity"/>
     </SplitPlaceholderRule>

--- a/CanonicalLayouts/list-detail-compose/app/src/main/java/com/example/listdetailcompose/ui/ListDetailSample.kt
+++ b/CanonicalLayouts/list-detail-compose/app/src/main/java/com/example/listdetailcompose/ui/ListDetailSample.kt
@@ -95,8 +95,8 @@ fun ListDetailSample(
         setIsDetailOpen = { isDetailOpen = it },
         showListAndDetail =
             when (widthSizeClass) {
-                WindowWidthSizeClass.Compact -> false
-                WindowWidthSizeClass.Medium, WindowWidthSizeClass.Expanded -> true
+                WindowWidthSizeClass.Compact, WindowWidthSizeClass.Medium -> false
+                WindowWidthSizeClass.Expanded -> true
                 else -> true
             },
         detailKey = selectedWordIndex,

--- a/CanonicalLayouts/list-detail-sliding-pane/app/src/main/res/layout/fragment_list.xml
+++ b/CanonicalLayouts/list-detail-sliding-pane/app/src/main/res/layout/fragment_list.xml
@@ -30,7 +30,7 @@
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/detail_container"
         android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="300dp"
+        android:layout_width="560dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
         app:defaultNavHost="true"


### PR DESCRIPTION
In line with the updated Material guidance at https://m3.material.io/foundations/layout/canonical-layouts/overview, switch our list detail examples to only show both the list and detail view when at an expanded width.