### PR TITLE
Fix broken README.md warning alert syntax

### DIFF
--- a/AppWidget/README.md
+++ b/AppWidget/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/DownloadableFonts/README.md
+++ b/DownloadableFonts/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/DragAndDrop/README.md
+++ b/DragAndDrop/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/Haptics/README.md
+++ b/Haptics/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/ImmersiveMode/README.md
+++ b/ImmersiveMode/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/Quick-Settings/README.md
+++ b/Quick-Settings/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > We are in the process of migrating these samples into the new [platform-samples repository](https://github.com/android/platform-samples).
 > 
 > You can find the list of migrated samples [here](https://github.com/android/platform-samples/tree/main/samples/user-interface)

--- a/Text/README.md
+++ b/Text/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/TextStyling/README.md
+++ b/TextStyling/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/WindowInsetsAnimation/README.md
+++ b/WindowInsetsAnimation/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 

--- a/WindowManager/README.md
+++ b/WindowManager/README.md
@@ -1,4 +1,4 @@
-> **Warning**
+> [!WARNING]
 > This sample has been migraated to the new [platform-samples repository](https://github.com/android/platform-samples)
 > and will no longer be maintained. 
 > 


### PR DESCRIPTION
Fixes the broken markdown syntax for the "warning" alert in the README. Changes `> **Warning**` to `> [!WARNING]` so the alert renders correctly again.

## Source
> ## Update - 14 November 2023
> * The initial syntax using e.g. `**Note**` isn't supported any longer.
> 
> ## Update - 21 July 2023
> * A new syntax, `[!NOTE]`, has been added, which will gradually replace the old one. However, the old syntax will continue to work for some time.
> 

https://github.com/orgs/community/discussions/16925