### PR TITLE
Replace FrameLayout with FragmentContainerView

### DIFF
--- a/People/app/src/main/res/layout/bubble_activity.xml
+++ b/People/app/src/main/res/layout/bubble_activity.xml
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<FrameLayout
+<androidx.fragment.app.FragmentContainerView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/container"
     android:layout_width="match_parent"

--- a/People/app/src/main/res/layout/main_activity.xml
+++ b/People/app/src/main/res/layout/main_activity.xml
@@ -67,7 +67,7 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="0dp"


### PR DESCRIPTION
> FragmentContainerView is a customized Layout designed specifically for Fragments. It extends FrameLayout, so it can reliably handle Fragment Transactions, and it also has additional features to coordinate with fragment behavior.

https://developer.android.com/reference/androidx/fragment/app/FragmentContainerView

Align with the usages like https://github.com/android/user-interface-samples/blob/4dc2385d266cc8818905451647ec4f54867901a5/CanonicalLayouts/list-detail-sliding-pane/app/src/main/res/layout/fragment_list.xml#L30-L31